### PR TITLE
Add instructions for conda setup with Apple silicon

### DIFF
--- a/conda-setup/README.md
+++ b/conda-setup/README.md
@@ -33,6 +33,20 @@ and then run it.
 This might take a few seconds as it installs every Python package we need. You find a description
 of what the batch script just did below. There is no need to run the commands.
 
+#### On a Mac with Apple Silicon
+
+There is a variant of that script for Mac computers with [Apple silicon](https://support.apple.com/en-us/HT211814).
+
+First, make sure it is executable using
+
+    $ chmod +x conda_setup_macos_m2.sh
+
+and then run it.
+
+    $ ./conda_setup_macos_m2.sh
+
+Apple's M1 and M2 chips bring their own GPU, so there is no need to deal with Cuda and NVidia settings.
+
 ---
 
 #### 1 Install Python Packages

--- a/conda-setup/conda_setup_macos_m2.sh
+++ b/conda-setup/conda_setup_macos_m2.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+conda env create -f tf_environment_macos_m2.yaml
+source $CONDA_PREFIX/bin/activate tf_py310

--- a/conda-setup/tf_environment_macos_m2.yaml
+++ b/conda-setup/tf_environment_macos_m2.yaml
@@ -1,0 +1,18 @@
+name: tf_py310
+channels:
+  - conda-forge
+  - nvidia
+  - apple
+dependencies:
+  - python=3.10
+  - pip
+  - apple::tensorflow-deps
+  - pip:
+    - tensorflow-macos
+    - tensorflow-metal
+    - keras-tuner
+    - matplotlib
+    - scipy
+    - prettytable
+    - seaborn
+    - plotly


### PR DESCRIPTION
Works for me (Macbook with Apple M2)

    $ cd conda-setup/
    $ chmod +x conda_setup_macos_m2.sh
    $ ./conda_setup_macos_m2.sh
    $ conda activate tf_py310
    $ python3 -c "import tensorflow as tf; print(tf.config.list_physical_devices('GPU'))"
    [PhysicalDevice(name='/physical_device:GPU:0', device_type='GPU')]